### PR TITLE
crystal2nix creates a new format

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -106,16 +106,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1651093906,
-        "narHash": "sha256-kHXSbv+Hc73eV0/JVJ5YsJGr08bA4vJ3/XZew5PgZg0=",
+        "lastModified": 1658406394,
+        "narHash": "sha256-hgibXbbmxucpVJy9eOXKn7HxQtVkpeZ8euSnWl6c9Mk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "feea25c58657fa81d16e0e51f80e1a02ef4cbd49",
+        "rev": "c93e5ab157b45adbb6165bd85a9d8f67e49ff31d",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-21.11",
+        "ref": "nixos-22.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -134,12 +134,17 @@
       }
     },
     "utils": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
       "locked": {
-        "lastModified": 1628100524,
-        "narHash": "sha256-vqI3p9fNj0C4ykTwMjryztszLHq9YU7AUkRJ9BK7rpE=",
+        "lastModified": 1644616305,
+        "narHash": "sha256-yxr3yyDa5NqIuXPWLIS91BLJCCJkzeCzNzOUqpnwAaU=",
         "owner": "kreisys",
         "repo": "flake-utils",
-        "rev": "7e5e32b9b20e6091adf27d7cdb1e0a0578b6f4f6",
+        "rev": "1c76d00ac669224a92079fe10086133a6922adee",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,8 +2,11 @@
   description = "Flake for Crystal";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-21.11";
-    utils.url = "github:kreisys/flake-utils";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.05";
+    utils = {
+      url = "github:kreisys/flake-utils";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
 
     crystal-src = {
       url = "github:crystal-lang/crystal/1.4.1";

--- a/pkgs/crystal/build-crystal-package.nix
+++ b/pkgs/crystal/build-crystal-package.nix
@@ -1,29 +1,35 @@
+{ stdenv
+, lib
+, crystal
+, shards
+, git
+, pkg-config
+, which
+, linkFarm
+, fetchgit
+, fetchFromGitHub
+, installShellFiles
+, removeReferencesTo
+}:
+
 {
-  stdenv,
-  lib,
-  crystal,
-  shards,
-  git,
-  pkg-config,
-  which,
-  linkFarm,
-  fetchFromGitHub,
-  installShellFiles,
-}: {
   # Some projects do not include a lock file, so you can pass one
-  lockFile ? null,
+  lockFile ? null
   # Generate shards.nix with `nix-shell -p crystal2nix --run crystal2nix` in the projects root
-  shardsFile ? null,
+, shardsFile ? null
   # We support different builders. To make things more straight forward, make it
   # user selectable instead of trying to autodetect
-  format ? "make",
-  installManPages ? true,
+, format ? "make"
+, installManPages ? true
   # Specify binaries to build in the form { foo.src = "src/foo.cr"; }
-  # The default `crystal build` options can be overridden with { foo.options = [ "--no-debug" ]; }
-  crystalBinaries ? {},
-  ...
-} @ args:
-assert (builtins.elem format ["make" "crystal" "shards"]); let
+  # The default `crystal build` options can be overridden with { foo.options = [ "--optionname" ]; }
+, crystalBinaries ? { }
+, enableParallelBuilding ? true
+, ...
+}@args:
+
+assert (builtins.elem format [ "make" "crystal" "shards" ]);
+let
   mkDerivationArgs = builtins.removeAttrs args [
     "format"
     "installManPages"
@@ -32,122 +38,122 @@ assert (builtins.elem format ["make" "crystal" "shards"]); let
     "crystalBinaries"
   ];
 
-  crystalLib = linkFarm "crystal-lib" (lib.mapAttrsToList (name: value: {
-    inherit name;
-    path = fetchFromGitHub value;
-  }) (import shardsFile));
-
-  # we previously had --no-debug here but that is not recommended by upstream
-  defaultOptions = ["--release" "--progress" "--verbose"];
-
-  buildDirectly = shardsFile == null || crystalBinaries != {};
-in
-  stdenv.mkDerivation (mkDerivationArgs
-    // {
-      configurePhase =
-        args.configurePhase or lib.concatStringsSep "\n"
-        (["runHook preConfigure"]
-          ++ lib.optional (lockFile != null) "cp ${lockFile} ./shard.lock"
-          ++ lib.optionals (shardsFile != null) [
-            "test -e lib || mkdir lib"
-            "for d in ${crystalLib}/*; do ln -s $d lib/; done"
-            "cp shard.lock lib/.shards.info"
-          ]
-          ++ ["runHook postConfigure"]);
-
-      CRFLAGS = lib.concatStringsSep " " defaultOptions;
-
-      PREFIX = placeholder "out";
-
-      buildInputs =
-        args.buildInputs
-        or []
-        ++ [crystal]
-        ++ lib.optional (format != "crystal") shards;
-
-      nativeBuildInputs =
-        args.nativeBuildInputs
-        or []
-        ++ [git installShellFiles pkg-config which];
-
-      buildPhase =
-        args.buildPhase
-        or (lib.concatStringsSep "\n"
-          (["runHook preBuild"]
-            ++ lib.optional (format == "make")
-            "make \${buildTargets:-build} $makeFlags"
-            ++ lib.optionals (format == "crystal") (lib.mapAttrsToList (bin: attrs: ''
-                crystal ${
-                  lib.escapeShellArgs ([
-                      "build"
-                      "-o"
-                      bin
-                      (attrs.src
-                        or (throw
-                          "No source file for crystal binary ${bin} provided"))
-                    ]
-                    ++ (attrs.options or defaultOptions))
-                }
-              '')
-              crystalBinaries)
-            ++ lib.optional (format == "shards")
-            "shards build --local --production ${
-              lib.concatStringsSep " " defaultOptions
-            }"
-            ++ ["runHook postBuild"]));
-
-      installPhase =
-        args.installPhase
-        or (lib.concatStringsSep "\n"
-          (["runHook preInstall"]
-            ++ lib.optional (format == "make")
-            "make \${installTargets:-install} $installFlags"
-            ++ lib.optionals (format == "crystal") (map (bin: ''
-              install -Dm555 ${
-                lib.escapeShellArgs [bin "${placeholder "out"}/bin/${bin}"]
-              }
-            '') (lib.attrNames crystalBinaries))
-            ++ lib.optional (format == "shards") "install -Dm555 bin/* -t $out/bin"
-            ++ [
-              ''
-                for f in README* *.md LICENSE; do
-                  test -f $f && install -Dm444 $f -t $out/share/doc/${args.pname}
-                done
-              ''
-            ]
-            ++ (lib.optional installManPages ''
-              if [ -d man ]; then
-                installManPage man/*.?
-              fi
-            '')
-            ++ ["runHook postInstall"]));
-
-      doCheck = args.doCheck or true;
-
-      checkPhase =
-        args.checkPhase
-        or (lib.concatStringsSep "\n"
-          (["runHook preCheck"]
-            ++ lib.optional (format == "make")
-            "make \${checkTarget:-test} $checkFlags"
-            ++ lib.optional (format != "make")
-            "crystal \${checkTarget:-spec} $checkFlags"
-            ++ ["runHook postCheck"]));
-
-      doInstallCheck = args.doInstallCheck or true;
-
-      installCheckPhase =
-        args.installCheckPhase
-        or ''
-          for f in $out/bin/*; do
-            $f --help
-          done
-        '';
-
-      meta =
-        args.meta
-        or {}
-        // {
-          platforms = args.meta.platforms or crystal.meta.platforms;
-        };
+  crystalLib = linkFarm "crystal-lib" (lib.mapAttrsToList
+    (name: value: {
+      inherit name;
+      path =
+        if (builtins.hasAttr "url" value)
+        then fetchgit value
+        else fetchFromGitHub value;
     })
+    (import shardsFile));
+
+  defaultOptions = [ "--release" "--progress" "--verbose" "--no-debug" ];
+
+  buildDirectly = shardsFile == null || crystalBinaries != { };
+
+  mkCrystalBuildArgs = bin: attrs:
+    lib.concatStringsSep " " ([
+      "crystal"
+      "build"
+    ] ++ lib.optionals enableParallelBuilding [
+      "--threads"
+      "$NIX_BUILD_CORES"
+    ] ++ [
+      "-o"
+      bin
+      (attrs.src or (throw "No source file for crystal binary ${bin} provided"))
+      (lib.concatStringsSep " " (attrs.options or defaultOptions))
+    ]);
+
+in
+stdenv.mkDerivation (mkDerivationArgs // {
+
+  configurePhase = args.configurePhase or lib.concatStringsSep "\n"
+    (
+      [
+        "runHook preConfigure"
+      ]
+      ++ lib.optional (lockFile != null) "cp ${lockFile} ./shard.lock"
+      ++ lib.optionals (shardsFile != null) [
+        "test -e lib || mkdir lib"
+        "for d in ${crystalLib}/*; do ln -s $d lib/; done"
+        "cp shard.lock lib/.shards.info"
+      ]
+      ++ [ "runHook postConfigure" ]
+    );
+
+  CRFLAGS = lib.concatStringsSep " " defaultOptions;
+
+  PREFIX = placeholder "out";
+
+  inherit enableParallelBuilding;
+  strictDeps = true;
+  buildInputs = args.buildInputs or [ ] ++ [ crystal ];
+
+  nativeBuildInputs = args.nativeBuildInputs or [ ] ++ [
+    crystal
+    git
+    installShellFiles
+    removeReferencesTo
+    pkg-config
+    which
+  ] ++ lib.optional (format != "crystal") shards;
+
+  buildPhase = args.buildPhase or (lib.concatStringsSep "\n" ([
+    "runHook preBuild"
+  ] ++ lib.optional (format == "make")
+    "make \${buildTargets:-build} $makeFlags"
+  ++ lib.optionals (format == "crystal") (lib.mapAttrsToList mkCrystalBuildArgs crystalBinaries)
+  ++ lib.optional (format == "shards")
+    "shards build --local --production ${lib.concatStringsSep " " (args.options or defaultOptions)}"
+  ++ [ "runHook postBuild" ]));
+
+  installPhase = args.installPhase or (lib.concatStringsSep "\n" ([
+    "runHook preInstall"
+  ] ++ lib.optional (format == "make")
+    "make \${installTargets:-install} $installFlags"
+  ++ lib.optionals (format == "crystal") (map
+    (bin: ''
+      install -Dm555 ${lib.escapeShellArgs [ bin "${placeholder "out"}/bin/${bin}" ]}
+    '')
+    (lib.attrNames crystalBinaries))
+  ++ lib.optional (format == "shards")
+    "install -Dm555 bin/* -t $out/bin"
+  ++ [
+    ''
+      for f in README* *.md LICENSE; do
+        test -f $f && install -Dm444 $f -t $out/share/doc/${args.pname}
+      done
+    ''
+  ] ++ (lib.optional installManPages ''
+    if [ -d man ]; then
+      installManPage man/*.?
+    fi
+  '') ++ [
+    "remove-references-to -t ${lib.getLib crystal} $out/bin/*"
+    "runHook postInstall"
+  ]));
+
+  doCheck = args.doCheck or true;
+
+  checkPhase = args.checkPhase or (lib.concatStringsSep "\n" ([
+    "runHook preCheck"
+  ] ++ lib.optional (format == "make")
+    "make \${checkTarget:-test} $checkFlags"
+  ++ lib.optional (format != "make")
+    "crystal \${checkTarget:-spec} $checkFlags"
+  ++ [ "runHook postCheck" ]));
+
+  doInstallCheck = args.doInstallCheck or true;
+
+  installCheckPhase = args.installCheckPhase or ''
+    for f in $out/bin/*; do
+      $f --help > /dev/null
+    done
+  '';
+
+  meta = args.meta or { } // {
+    platforms = args.meta.platforms or crystal.meta.platforms;
+  };
+})


### PR DESCRIPTION
crystal2nix previously only handled github sources but v0.3.0 introduced a new format for arbitrary git sources. However, this requires the build infra to also know when to invoke which fetcher so this PR copies over the crystal builder verbatim from nixpkgs.

Also bump to 22.05.