### PR TITLE
crystal: 1.7.0 -> 1.7.3

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -37,40 +37,40 @@
     "crystal-aarch64-darwin": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-1jEBZ/yJQRxnd1JMxcUOOC6TDMjcL7Vbu7aXFbsHoxM=",
+        "narHash": "sha256-eU5JsJBXLZBQu0y6u2qF3QImgIzra6j+gftWM1hzg8k=",
         "type": "tarball",
-        "url": "https://github.com/crystal-lang/crystal/releases/download/1.7.2/crystal-1.7.2-1-darwin-universal.tar.gz"
+        "url": "https://github.com/crystal-lang/crystal/releases/download/1.7.3/crystal-1.7.3-1-darwin-universal.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/crystal-lang/crystal/releases/download/1.7.2/crystal-1.7.2-1-darwin-universal.tar.gz"
+        "url": "https://github.com/crystal-lang/crystal/releases/download/1.7.3/crystal-1.7.3-1-darwin-universal.tar.gz"
       }
     },
     "crystal-i686-linux": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-nvaWphML6iq+XRDM+hf0l7cI1/hPXRXkaAF6ur+uY1Y=",
+        "narHash": "sha256-YMvEPfC+7qvhBQaeaGcvrgRQgdkAORDGzqB5YE40ODY=",
         "type": "tarball",
-        "url": "https://github.com/crystal-lang/crystal/releases/download/1.7.2/crystal-1.7.2-1-linux-x86_64.tar.gz"
+        "url": "https://github.com/crystal-lang/crystal/releases/download/1.7.3/crystal-1.7.3-1-linux-x86_64.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/crystal-lang/crystal/releases/download/1.7.2/crystal-1.7.2-1-linux-x86_64.tar.gz"
+        "url": "https://github.com/crystal-lang/crystal/releases/download/1.7.3/crystal-1.7.3-1-linux-x86_64.tar.gz"
       }
     },
     "crystal-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1674493517,
-        "narHash": "sha256-Bwd9Gmtwa/0oLhps3fc8GqBlB4o31LCR1Sf98Pz4i90=",
+        "lastModified": 1678199101,
+        "narHash": "sha256-ULhLGHRIZbsKhaMvNhc+W74BwNgfEjHcMnVNApWY+EE=",
         "owner": "crystal-lang",
         "repo": "crystal",
-        "rev": "29f9ac503fb028e1b095c8f8e036ed74b5474550",
+        "rev": "d61a01e185baf84046efce50832a97f097ba0a2f",
         "type": "github"
       },
       "original": {
         "owner": "crystal-lang",
-        "ref": "1.7.2",
+        "ref": "1.7.3",
         "repo": "crystal",
         "type": "github"
       }
@@ -78,25 +78,25 @@
     "crystal-x86_64-darwin": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-nvaWphML6iq+XRDM+hf0l7cI1/hPXRXkaAF6ur+uY1Y=",
+        "narHash": "sha256-YMvEPfC+7qvhBQaeaGcvrgRQgdkAORDGzqB5YE40ODY=",
         "type": "tarball",
-        "url": "https://github.com/crystal-lang/crystal/releases/download/1.7.2/crystal-1.7.2-1-linux-x86_64.tar.gz"
+        "url": "https://github.com/crystal-lang/crystal/releases/download/1.7.3/crystal-1.7.3-1-linux-x86_64.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/crystal-lang/crystal/releases/download/1.7.2/crystal-1.7.2-1-linux-x86_64.tar.gz"
+        "url": "https://github.com/crystal-lang/crystal/releases/download/1.7.3/crystal-1.7.3-1-linux-x86_64.tar.gz"
       }
     },
     "crystal-x86_64-linux": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-nvaWphML6iq+XRDM+hf0l7cI1/hPXRXkaAF6ur+uY1Y=",
+        "narHash": "sha256-YMvEPfC+7qvhBQaeaGcvrgRQgdkAORDGzqB5YE40ODY=",
         "type": "tarball",
-        "url": "https://github.com/crystal-lang/crystal/releases/download/1.7.2/crystal-1.7.2-1-linux-x86_64.tar.gz"
+        "url": "https://github.com/crystal-lang/crystal/releases/download/1.7.3/crystal-1.7.3-1-linux-x86_64.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/crystal-lang/crystal/releases/download/1.7.2/crystal-1.7.2-1-linux-x86_64.tar.gz"
+        "url": "https://github.com/crystal-lang/crystal/releases/download/1.7.3/crystal-1.7.3-1-linux-x86_64.tar.gz"
       }
     },
     "crystalline-src": {

--- a/flake.lock
+++ b/flake.lock
@@ -3,16 +3,16 @@
     "ameba-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1668496515,
-        "narHash": "sha256-SZ2sBQeZgtPOYioH9eK5MveFtWVGPvgKMrqsCfjoRGM=",
+        "lastModified": 1677051617,
+        "narHash": "sha256-coZU3cufQgSCid10zEvmHG7ddLbZhnrvl9ffw4Y6h74=",
         "owner": "crystal-ameba",
         "repo": "ameba",
-        "rev": "cc687d028180203cb53390484871ffb8669b88c8",
+        "rev": "6f05df4006e82ba05a55dcfa831f6dbdb3b0191d",
         "type": "github"
       },
       "original": {
         "owner": "crystal-ameba",
-        "ref": "v1.3.1",
+        "ref": "v1.4.2",
         "repo": "ameba",
         "type": "github"
       }
@@ -37,40 +37,40 @@
     "crystal-aarch64-darwin": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-P8tcXB+aTHHMLigrqrSpvTsC5t1q4AFxPyLLTsSD7/I=",
+        "narHash": "sha256-1jEBZ/yJQRxnd1JMxcUOOC6TDMjcL7Vbu7aXFbsHoxM=",
         "type": "tarball",
-        "url": "https://github.com/crystal-lang/crystal/releases/download/1.7.0/crystal-1.7.0-1-darwin-universal.tar.gz"
+        "url": "https://github.com/crystal-lang/crystal/releases/download/1.7.2/crystal-1.7.2-1-darwin-universal.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/crystal-lang/crystal/releases/download/1.7.0/crystal-1.7.0-1-darwin-universal.tar.gz"
+        "url": "https://github.com/crystal-lang/crystal/releases/download/1.7.2/crystal-1.7.2-1-darwin-universal.tar.gz"
       }
     },
     "crystal-i686-linux": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-3s1KKV3UuMZfUqULWCWl6XKrHOVufnfcgEOJ0d5jnLQ=",
+        "narHash": "sha256-nvaWphML6iq+XRDM+hf0l7cI1/hPXRXkaAF6ur+uY1Y=",
         "type": "tarball",
-        "url": "https://github.com/crystal-lang/crystal/releases/download/1.7.0/crystal-1.7.0-1-linux-x86_64.tar.gz"
+        "url": "https://github.com/crystal-lang/crystal/releases/download/1.7.2/crystal-1.7.2-1-linux-x86_64.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/crystal-lang/crystal/releases/download/1.7.0/crystal-1.7.0-1-linux-x86_64.tar.gz"
+        "url": "https://github.com/crystal-lang/crystal/releases/download/1.7.2/crystal-1.7.2-1-linux-x86_64.tar.gz"
       }
     },
     "crystal-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1673282978,
-        "narHash": "sha256-no6b6PGmc/dhicMLVZIHwi/HOKCVTiWHZ5I+ImBjoQc=",
+        "lastModified": 1674493517,
+        "narHash": "sha256-Bwd9Gmtwa/0oLhps3fc8GqBlB4o31LCR1Sf98Pz4i90=",
         "owner": "crystal-lang",
         "repo": "crystal",
-        "rev": "016578f858cd08efc035a9c66a82965efc75321c",
+        "rev": "29f9ac503fb028e1b095c8f8e036ed74b5474550",
         "type": "github"
       },
       "original": {
         "owner": "crystal-lang",
-        "ref": "1.7.0",
+        "ref": "1.7.2",
         "repo": "crystal",
         "type": "github"
       }
@@ -78,25 +78,25 @@
     "crystal-x86_64-darwin": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-3s1KKV3UuMZfUqULWCWl6XKrHOVufnfcgEOJ0d5jnLQ=",
+        "narHash": "sha256-nvaWphML6iq+XRDM+hf0l7cI1/hPXRXkaAF6ur+uY1Y=",
         "type": "tarball",
-        "url": "https://github.com/crystal-lang/crystal/releases/download/1.7.0/crystal-1.7.0-1-linux-x86_64.tar.gz"
+        "url": "https://github.com/crystal-lang/crystal/releases/download/1.7.2/crystal-1.7.2-1-linux-x86_64.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/crystal-lang/crystal/releases/download/1.7.0/crystal-1.7.0-1-linux-x86_64.tar.gz"
+        "url": "https://github.com/crystal-lang/crystal/releases/download/1.7.2/crystal-1.7.2-1-linux-x86_64.tar.gz"
       }
     },
     "crystal-x86_64-linux": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-3s1KKV3UuMZfUqULWCWl6XKrHOVufnfcgEOJ0d5jnLQ=",
+        "narHash": "sha256-nvaWphML6iq+XRDM+hf0l7cI1/hPXRXkaAF6ur+uY1Y=",
         "type": "tarball",
-        "url": "https://github.com/crystal-lang/crystal/releases/download/1.7.0/crystal-1.7.0-1-linux-x86_64.tar.gz"
+        "url": "https://github.com/crystal-lang/crystal/releases/download/1.7.2/crystal-1.7.2-1-linux-x86_64.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/crystal-lang/crystal/releases/download/1.7.0/crystal-1.7.0-1-linux-x86_64.tar.gz"
+        "url": "https://github.com/crystal-lang/crystal/releases/download/1.7.2/crystal-1.7.2-1-linux-x86_64.tar.gz"
       }
     },
     "crystalline-src": {
@@ -136,16 +136,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1658406394,
-        "narHash": "sha256-hgibXbbmxucpVJy9eOXKn7HxQtVkpeZ8euSnWl6c9Mk=",
+        "lastModified": 1677543769,
+        "narHash": "sha256-LwbqS8vGisXl2WHpK9r5+kodr0zoIT8F2YB0R4y1TsA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c93e5ab157b45adbb6165bd85a9d8f67e49ff31d",
+        "rev": "b26d52c9feb6476580016e78935cbf96eb3e2115",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-22.05",
+        "ref": "nixos-22.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -6,27 +6,27 @@
     flake-parts.url = "github:hercules-ci/flake-parts";
 
     crystal-src = {
-      url = "github:crystal-lang/crystal/1.7.0";
+      url = "github:crystal-lang/crystal/1.7.2";
       flake = false;
     };
 
     crystal-i686-linux = {
-      url = "https://github.com/crystal-lang/crystal/releases/download/1.7.0/crystal-1.7.0-1-linux-x86_64.tar.gz";
+      url = "https://github.com/crystal-lang/crystal/releases/download/1.7.2/crystal-1.7.2-1-linux-x86_64.tar.gz";
       flake = false;
     };
 
     crystal-x86_64-darwin = {
-      url = "https://github.com/crystal-lang/crystal/releases/download/1.7.0/crystal-1.7.0-1-linux-x86_64.tar.gz";
+      url = "https://github.com/crystal-lang/crystal/releases/download/1.7.2/crystal-1.7.2-1-linux-x86_64.tar.gz";
       flake = false;
     };
 
     crystal-x86_64-linux = {
-      url = "https://github.com/crystal-lang/crystal/releases/download/1.7.0/crystal-1.7.0-1-linux-x86_64.tar.gz";
+      url = "https://github.com/crystal-lang/crystal/releases/download/1.7.2/crystal-1.7.2-1-linux-x86_64.tar.gz";
       flake = false;
     };
 
     crystal-aarch64-darwin = {
-      url = "https://github.com/crystal-lang/crystal/releases/download/1.7.0/crystal-1.7.0-1-darwin-universal.tar.gz";
+      url = "https://github.com/crystal-lang/crystal/releases/download/1.7.2/crystal-1.7.2-1-darwin-universal.tar.gz";
       flake = false;
     };
 
@@ -41,7 +41,7 @@
     };
 
     ameba-src = {
-      url = "github:crystal-ameba/ameba/v1.3.1";
+      url = "github:crystal-ameba/ameba/v1.4.2";
       flake = false;
     };
   };
@@ -58,10 +58,10 @@
         ...
       }: {
         overlayAttrs = let
-          crystalVersion = "1.7.0";
+          crystalVersion = "1.7.2";
           crystallineVersion = "0.8.0";
           bdwgcVersion = "8.2.2";
-          amebaVersion = "1.3.1";
+          amebaVersion = "1.4.2";
           llvmPackages = pkgs.llvmPackages_11;
         in {
           bdwgc = pkgs.callPackage ./pkgs/bdwgc {

--- a/flake.nix
+++ b/flake.nix
@@ -6,27 +6,27 @@
     flake-parts.url = "github:hercules-ci/flake-parts";
 
     crystal-src = {
-      url = "github:crystal-lang/crystal/1.7.2";
+      url = "github:crystal-lang/crystal/1.7.3";
       flake = false;
     };
 
     crystal-i686-linux = {
-      url = "https://github.com/crystal-lang/crystal/releases/download/1.7.2/crystal-1.7.2-1-linux-x86_64.tar.gz";
+      url = "https://github.com/crystal-lang/crystal/releases/download/1.7.3/crystal-1.7.3-1-linux-x86_64.tar.gz";
       flake = false;
     };
 
     crystal-x86_64-darwin = {
-      url = "https://github.com/crystal-lang/crystal/releases/download/1.7.2/crystal-1.7.2-1-linux-x86_64.tar.gz";
+      url = "https://github.com/crystal-lang/crystal/releases/download/1.7.3/crystal-1.7.3-1-linux-x86_64.tar.gz";
       flake = false;
     };
 
     crystal-x86_64-linux = {
-      url = "https://github.com/crystal-lang/crystal/releases/download/1.7.2/crystal-1.7.2-1-linux-x86_64.tar.gz";
+      url = "https://github.com/crystal-lang/crystal/releases/download/1.7.3/crystal-1.7.3-1-linux-x86_64.tar.gz";
       flake = false;
     };
 
     crystal-aarch64-darwin = {
-      url = "https://github.com/crystal-lang/crystal/releases/download/1.7.2/crystal-1.7.2-1-darwin-universal.tar.gz";
+      url = "https://github.com/crystal-lang/crystal/releases/download/1.7.3/crystal-1.7.3-1-darwin-universal.tar.gz";
       flake = false;
     };
 
@@ -58,7 +58,7 @@
         ...
       }: {
         overlayAttrs = let
-          crystalVersion = "1.7.2";
+          crystalVersion = "1.7.3";
           crystallineVersion = "0.8.0";
           bdwgcVersion = "8.2.2";
           amebaVersion = "1.4.2";

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Flake for Crystal";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.05";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.11";
     flake-parts.url = "github:hercules-ci/flake-parts";
 
     crystal-src = {


### PR DESCRIPTION
As well as a functioning ameba!

The input was bumped from 22.05 to 22.11 as 22.05 is no longer supported.