### PR TITLE
Fix darwin compilation

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -78,13 +78,13 @@
     "crystal-x86_64-darwin": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-YMvEPfC+7qvhBQaeaGcvrgRQgdkAORDGzqB5YE40ODY=",
+        "narHash": "sha256-eU5JsJBXLZBQu0y6u2qF3QImgIzra6j+gftWM1hzg8k=",
         "type": "tarball",
-        "url": "https://github.com/crystal-lang/crystal/releases/download/1.7.3/crystal-1.7.3-1-linux-x86_64.tar.gz"
+        "url": "https://github.com/crystal-lang/crystal/releases/download/1.7.3/crystal-1.7.3-1-darwin-universal.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/crystal-lang/crystal/releases/download/1.7.3/crystal-1.7.3-1-linux-x86_64.tar.gz"
+        "url": "https://github.com/crystal-lang/crystal/releases/download/1.7.3/crystal-1.7.3-1-darwin-universal.tar.gz"
       }
     },
     "crystal-x86_64-linux": {

--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,7 @@
     };
 
     crystal-x86_64-darwin = {
-      url = "https://github.com/crystal-lang/crystal/releases/download/1.7.3/crystal-1.7.3-1-linux-x86_64.tar.gz";
+      url = "https://github.com/crystal-lang/crystal/releases/download/1.7.3/crystal-1.7.3-1-darwin-universal.tar.gz";
       flake = false;
     };
 

--- a/pkgs/crystal/default.nix
+++ b/pkgs/crystal/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   llvmPackages,
   clang11Stdenv,
   llvm_11,
@@ -18,6 +19,7 @@
   libyaml,
   gmp,
   pcre,
+  libiconv,
   hostname,
   coreutils,
   callPackage,
@@ -38,9 +40,9 @@ lib.fix (compiler:
 
       nativeBuildInputs = [makeWrapper removeReferencesTo llvm_11 pkg-config crystal-bin];
 
-      buildInputs = [bdwgc gmp libevent libxml2 libyaml openssl pcre readline zlib];
+      buildInputs = [bdwgc gmp libevent libxml2 libyaml openssl pcre readline zlib] ++ lib.optionals stdenv.isDarwin [ libiconv ];
 
-      checkInputs = [which git gmp openssl readline libxml2 libyaml];
+      checkInputs = [which git gmp openssl readline libxml2 libyaml] ++ lib.optionals stdenv.isDarwin [ libiconv ];
 
       disallowedReferences = [crystal-bin];
 

--- a/pkgs/crystal/package-bin.nix
+++ b/pkgs/crystal/package-bin.nix
@@ -13,7 +13,13 @@ lib.fix (compiler:
       passthru.buildCrystalPackage =
         callPackage ./build-crystal-package.nix {crystal = compiler;};
 
-      installPhase = ''
+      installPhase = if stdenv.isDarwin then
+      ''
+        mkdir -p $out/bin/
+        cp embedded/bin/crystal $out/bin/
+      ''      
+      else
+      ''
         mkdir -p $out
         cp -r bin lib share $out
       '';


### PR DESCRIPTION
Hi did a small pass and got the flake building on aarch64-darwin and x86_64-darwin it seems. 

- The crystal binary is in a different location in the darwin.tar.gz
- The input url for x86_64-darwin was wrong

As validation I did:

```
nix build .#crystal
./result-bin/bin/crystal --version
./result-bin/bin/crystal eval 'puts "Hello"'
./result-bin/bin/crystal env

nix build .#ameba
./result/bin/ameba --version
./result/bin/ameba --help
```

I'm not sure how to make the libiconv optional for linux in the default.nix argument list.