### PR TITLE
Make Crystal default target match Nix target platform

### DIFF
--- a/pkgs/crystal/default.nix
+++ b/pkgs/crystal/default.nix
@@ -56,6 +56,7 @@ lib.fix (compiler:
 
       LLVM_CONFIG = "${llvm_11.dev}/bin/llvm-config";
       CRYSTAL_LIBRARY_PATH = "${placeholder "lib"}/crystal";
+      CRYSTAL_CONFIG_TARGET = stdenv.targetPlatform.config;
       FLAGS = ["--threads=\${NIX_BUILD_CORES}"];
 
       postPatch = ''


### PR DESCRIPTION
When building the Crystal compiler, it picks a default LLVM target triple by either looking at the env var CRYSTAL_CONFIG_TARGET if set, or by calling LLVMGetDefaultTargetTriple on the linked LLVM.

On nix linux builds of Crystal using the LLVM function seems to be fine. However on MacOS, it can cause a mismatch with nix's MacOS stdenv.

stdenv.targetPlatform.darwinMinVersion defaults to "11.0" and this makes it's way into all the clang and ld wrapper scripts. However, the default LLVM target can be something such as "aarch64-apple-darwin22.3.0" which would translate to kernel version 13. Then Crystal would build .o files targeting 13, and the wrapped clang/ld would try and link them to be compatible with 11 and generate hundreds of warning messages such as "<file> was built for newer macOS version (13.0) than being linked (11.0)".

By setting the CRYSTAL_CONFIG_TARGET to match the nix targetPlatform, the default target for the compiler becomes just "aarch64-apple-darwin", and everything works as expected.

On linux setting this env var has no effect, since the LLVM detected triple matches that of the nix targetPlatform.